### PR TITLE
Convert to Rust RFC2873 asm syntax as rusty-dos no longer works

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 build = "build.rs"
 
 [dependencies]
-rusty-asm = "0.2"
 bitflags = "1.0"
 sjis-literals = { path = "sjis-literals" }
 

--- a/src/dos.rs
+++ b/src/dos.rs
@@ -1,77 +1,58 @@
-use rusty_asm::rusty_asm;
-
 pub fn print(s: *const u8) {
     unsafe {
-        rusty_asm! {
-            let ptr: in("{dx}") = s;
-            clobber("ah");
-            clobber("al");
-            asm("volatile", "intel") {
-                "mov ah, 09h
-                int 21h"
-            }
-        }
+        asm!(
+            "int 21h",
+            inout("ax") 0x0900 => _,
+            in("dx") s,
+        );
     }
 }
 
 pub fn print_character(c: u8) {
     unsafe {
-        rusty_asm! {
-            let byte: in("{dl}") = c;
-            clobber("ah");
-            clobber("al");
-            asm("volatile", "intel") {
-                "mov ah, 02h
-                int 21h"
-            }
-        }
+        asm!(
+            "int 21h",
+            inout("ax") 0x0200 => _,
+            in("dl") c,
+        );
     }
 }
 
 pub fn get_keyboard_input() -> u8 {
+    let code;
     unsafe {
-        rusty_asm! {
-            let code: out("{ax}");
-            asm("volatile", "intel") {
-                "mov  ah,01h
-                 int  16h
-                 jz   empty
-                 mov  ah,00h
-                 int  16h
-                 mov  al,ah
-
-                 xor  ah,ah
-                 jmp  done
-                 
-                 empty:
-                    xor ax,ax
-                 done:"
-            }
-            return code;
-        }
+        asm!(
+            "mov ah, 01h",
+            "int 16h",
+            "jz empty",
+            "mov ah, 00h",
+            "int 16h",
+            "mov al, ah",
+            "xor ah, ah",
+            "jmp done",
+            "empty:",
+            "xor ax, ax",
+            "done:",
+            out("al") code,
+        );
     }
+    code
 }
 
-pub fn set_video_mode(m: u8) {
+pub fn set_video_mode(mode: u8) {
     unsafe {
-        rusty_asm! {
-            let mode: in("{al}") = m as u8;
-            clobber("ax");
-            asm("volatile", "intel") {
-                "mov ah, 0
-                int 10h"
-            }
-        }
+        asm!(
+            "int 10h",
+            inout("ax") mode as u16 => _,
+        );
     }
 }
 
 pub fn exit() {
     unsafe {
-        rusty_asm! {
-            asm("volatile", "intel") {
-                "mov ah, 4Ch
-                int 21h"
-            }
-        }
+        asm!(
+            "int 21h",
+            inout("ax") 0x4C00 => _,
+        );
     }
 }

--- a/src/port.rs
+++ b/src/port.rs
@@ -1,73 +1,62 @@
 #![allow(unused_assignments)] 
 
-use rusty_asm::rusty_asm;
-
 #[inline(always)]
 pub unsafe fn inb(port: u16) -> u8 {
-    rusty_asm! {
-        let port: in("{dx}") = port;
-        let mut value: out("{al}") = 0_u8;
-        asm("volatile", "intel") {
-            "in $value, dx"
-        }
-        value
-    }
+    let value;
+    asm!(
+        "in al, dx",
+        in("dx") port,
+        out("al") value,
+    );
+    value
 }
 
 #[inline(always)]
 pub unsafe fn inw(port: u16) -> u16 {
-    rusty_asm! {
-        let port: in("{dx}") = port;
-        let mut value: out("{ax}") = 0_u16;
-        asm("volatile", "intel") {
-            "in $value, dx"
-        }
-        value
-    }
+    let value;
+    asm!(
+        "in ax, dx",
+        in("dx") port,
+        out("ax") value,
+    );
+    value
 }
 
 #[inline(always)]
 pub unsafe fn inl(port: u16) -> u32 {
-    rusty_asm! {
-        let port: in("{dx}") = port;
-        let mut value: out("{eax}") = 0_u32;
-        asm("volatile", "intel") {
-            "in $value, dx"
-        }
-        value
-    }
+    let value;
+    asm!(
+        "in eax, dx",
+        in("dx") port,
+        out("eax") value,
+    );
+    value
 }
 
 #[inline(always)]
 pub unsafe fn outb(port: u16, value: u8) {
-    rusty_asm! {
-        let port: in("{dx}") = port;
-        let value: in("{al}") = value;
-        asm("volatile", "intel") {
-            "out dx, al"
-        }
-    }
+    asm!(
+        "out dx, al",
+        in("al") value,
+        in("dx") port,
+    );
 }
 
 #[inline(always)]
 pub unsafe fn outw(port: u16, value: u16) {
-    rusty_asm! {
-        let port: in("{dx}") = port;
-        let value: in("{ax}") = value;
-        asm("volatile", "intel") {
-            "out dx, ax"
-        }
-    }
+    asm!(
+        "out dx, ax",
+        in("ax") value,
+        in("dx") port,
+    );
 }
 
 #[inline(always)]
 pub unsafe fn outl(port: u16, value: u32) {
-    rusty_asm! {
-        let port: in("{dx}") = port;
-        let value: in("{eax}") = value;
-        asm("volatile", "intel") {
-            "out dx, eax"
-        }
-    }
+    asm!(
+        "out dx, eax",
+        in("eax") value,
+        in("dx") port,
+    );
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,43 +1,36 @@
-use rusty_asm::rusty_asm;
-
 pub fn random() -> u16 {
+    let value;
     unsafe {
-        rusty_asm! {
-            let ax: u16: out("{ax}");
-            clobber("bx");
-            clobber("cx");
-            clobber("dx");
-            asm("volatile", "intel") {
-                "mov   bx,[11h]
-                 mov   ax,bx
-                 shl   bx,7
-                 xor   ax,bx
-                 mov   bx,ax
-                 shr   bx,9
-                 xor   ax,bx
-                 mov   bx,ax
-                 shl   bx,8
-                 xor   ax,bx
-                 mov   [11h],ax"
-            }
-            return ax;
-        }
+        asm!(
+            "mov bx, [11h]",
+            "mov ax, bx",
+            "shl bx, 7",
+            "xor ax, bx",
+            "mov bx, ax",
+            "shr bx, 9",
+            "xor ax, bx",
+            "mov bx, ax",
+            "shl bx, 8",
+            "xor ax, bx",
+            "mov [11h], ax",
+            out("ax") value,
+            out("bx") _,
+            out("cx") _,
+            out("dx") _,
+        );
+        value
     }
 }
 
 pub fn seed_random() {
     unsafe {
-        rusty_asm! {
-            clobber("ax");
-            clobber("dx");
-            clobber("cx");
-            asm("volatile", "intel") {
-                "mov   ah,0
-                 int   1ah
-                 mov   [11h],dx
-                 xor   dx,dx
-                 xor   cx,cx"
-            }
-        }
+        asm!(
+            "int 1ah",
+            "mov [11h], dx",
+            "xor dx, dx",
+            inout("ax") 0 => _,
+            inout("cx") 0 => _,
+            out("dx") _,
+        );
     }
 }

--- a/src/video.rs
+++ b/src/video.rs
@@ -1,37 +1,26 @@
-use rusty_asm::rusty_asm;
-
-pub fn fill_screen(c: u8) {
+pub fn fill_screen(color: u8) {
     unsafe {
-        rusty_asm! {
-            let color: in("{dl}") = c;
-            clobber("ax");
-            asm("volatile", "intel") {
-                "mov   ax, 0A000h
-                 mov   es, ax
-                 xor   di, di
-                 mov   cx, 320*200/2
-                 mov   al,$color
-                 mov   ah, al
-                 rep   stosw
-                 
-                 ret"
-            }
-        }
+        asm!(
+            "mov   es, ax",
+            "xor   di, di",
+            "mov   cx, 320*200/2",
+            "mov   al, dl",
+            "mov   ah, al",
+            "rep   stosw",
+            inout("ax") 0xA000 => _,
+            in("dl") color,
+        )
     }
 }
 
 pub fn plot_pixel(x: u16, y: u16, color: u8) {
     unsafe {
-        rusty_asm! {
-            let c: in("{al}") = color as u8;
-            let mut px: in("{cx}") = x as u16;
-            let mut py: in("{dx}") = y as u16;
-            clobber("bh");
-            asm("volatile", "intel") {
-                "mov   ah,0ch
-                 mov   bh,0
-                 int   10h"
-            }
-        }
+        asm!(
+            "int 10h",
+            in("ax") (0x0C00u16) | (color as u16),
+            in("bh") 0u8,
+            in("cx") x,
+            in("dx") y,
+        );
     }
 }


### PR DESCRIPTION
Rust standardized a new inline assembly syntax June 8th, 2020 to replace the, as you said, cumbersome llvm inline assembly syntax. It's a bit different from the rusty_asm syntax, but it's significantly more readable that llvm asm was. rusty-asm doesn't work on current rust nightly releases (at least as of October 2020), it also doesn't appear to have been updated in a few years.

I've put together this PR to make the conversion and tested it in dosbox. I also tested the code without the video component on a 386EX SBC I have that runs General Software DOS-ROM (late 90's hardware).

see: https://blog.rust-lang.org/inside-rust/2020/06/08/new-inline-asm.html
see: https://doc.rust-lang.org/beta/unstable-book/library-features/asm.html